### PR TITLE
Complete Negotiate auth on any non-401 status code

### DIFF
--- a/requests_negotiate_sspi/requests_negotiate_sspi.py
+++ b/requests_negotiate_sspi/requests_negotiate_sspi.py
@@ -134,21 +134,20 @@ class HttpNegotiateAuth(AuthBase):
 
         # Should get another 401 if we are doing challenge-response (NTLM)
         if response2.status_code != 401:
-            if response2.status_code == 200:
-                # Kerberos may have succeeded; if so, finalize our auth context
-                final = response2.headers.get('WWW-Authenticate')
-                if final is not None:
-                    try:
-                        # Sometimes Windows seems to forget to prepend 'Negotiate' to the success response,
-                        # and we get just a bare chunk of base64 token. Not sure why.
-                        final = final.replace(scheme, '', 1).lstrip()
-                        tokenbuf = win32security.PySecBufferType(pkg_info['MaxToken'], sspicon.SECBUFFER_TOKEN)
-                        tokenbuf.Buffer = base64.b64decode(final)
-                        sec_buffer.append(tokenbuf)
-                        error, auth = clientauth.authorize(sec_buffer)
-                        _logger.debug('Kerberos Authentication succeeded - error={} authenticated={}'.format(error, clientauth.authenticated))
-                    except TypeError:
-                        pass
+            # Kerberos may have succeeded; if so, finalize our auth context
+            final = response2.headers.get('WWW-Authenticate')
+            if final is not None:
+                try:
+                    # Sometimes Windows seems to forget to prepend 'Negotiate' to the success response,
+                    # and we get just a bare chunk of base64 token. Not sure why.
+                    final = final.replace(scheme, '', 1).lstrip()
+                    tokenbuf = win32security.PySecBufferType(pkg_info['MaxToken'], sspicon.SECBUFFER_TOKEN)
+                    tokenbuf.Buffer = base64.b64decode(final.encode('ASCII'))
+                    sec_buffer.append(tokenbuf)
+                    error, auth = clientauth.authorize(sec_buffer)
+                    _logger.debug('Kerberos Authentication succeeded - error={} authenticated={}'.format(error, clientauth.authenticated))
+                except TypeError:
+                    pass
 
             # Regardless of whether or not we finalized our auth context,
             # without a 401 we've got nothing to do. Update the history and return.


### PR DESCRIPTION
Don't assume that the server completes authentication on 200 only.
It happens on any non-401 status code. E.g., 201, 3xx, 403, and so forth.
This especially applies for REST APIs.

For example:
```
PS> python .\test-requests.py
Starting new HTTPS connection (1): deblndw024v.ad001.siemens.net:8444
https://deblndw024v.ad001.siemens.net:8444 "HEAD /manager/html HTTP/1.1" 401 0
Sending Initial Context Token - error=590610 authenticated=False
https://deblndw024v.ad001.siemens.net:8444 "HEAD /manager/html HTTP/1.1" 403 0
Kerberos Authentication succeeded - error=0 authenticated=True
```

We're using this module with REST API which can return any status code after authentication has completed.
