### PR TITLE
Change pypiwin32 to pywin32 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pypiwin32 >= 223
+pywin32 >= 223
 requests >= 2.0


### PR DESCRIPTION
Seemingly (sources are scarce, but the wheels do make it look like that) pypiwin is just an old packaging of pywin. 
See #13 and https://old.reddit.com/r/learnpython/comments/fkr40q/how_to_install_win32api/fkumc2z/ for some context.

Fixes #13 

Should test that this works before merging