### PR TITLE
Support case-insensitve scheme match in challenge response

### DIFF
--- a/requests_negotiate_sspi/requests_negotiate_sspi.py
+++ b/requests_negotiate_sspi/requests_negotiate_sspi.py
@@ -142,7 +142,8 @@ class HttpNegotiateAuth(AuthBase):
                 try:
                     # Sometimes Windows seems to forget to prepend 'Negotiate' to the success response,
                     # and we get just a bare chunk of base64 token. Not sure why.
-                    final = final.replace(scheme, '', 1).lstrip()
+                    if final[0:len(scheme)].upper() == scheme.upper():
+                        final = final[len(scheme)+1:]
                     tokenbuf = win32security.PySecBufferType(pkg_info['MaxToken'], sspicon.SECBUFFER_TOKEN)
                     tokenbuf.Buffer = base64.b64decode(final.encode('ASCII'))
                     sec_buffer.append(tokenbuf)


### PR DESCRIPTION
This implements case-insensitive matching of the `Negotiate` scheme token for response messages in the challenge-response process.

[RFC-2616 Section 14.47](https://datatracker.ietf.org/doc/html/rfc2616#section-14.47) defers the definition of the Access Authentication Framework to [RFC-2617 Section 1.2](https://datatracker.ietf.org/doc/html/rfc2617#section-1.2). The latter states that:
> It uses an extensible, case-insensitive token to identify the authentication scheme, followed by a comma-separated list of attribute-value pairs which carry the parameters necessary for achieving authentication via that scheme.

Conformance with these specifications is re-affirmed in [RFC-4559 Section 3.1](https://datatracker.ietf.org/doc/html/rfc4559#section-3.1) concerning "SPNEGO-based Kerberos and NTLM HTTP Authentication in Microsoft Windows".

Whilst most implementations of `Negotiate` authentication mechanism use a capitalised `N` as in RFC-4559, RFC-2617 requires the scheme token be processed case-insensitively. A notable minority of servers have used this flexibility, so clients should be generally compatible with that decision. Introducing such compatibility does not create a breaking change as all previously supported casings of the scheme token remain supported.