### PR TITLE
Don't imply a default local domain (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,20 @@ r = requests.get('https://iis.contoso.com', auth=HttpNegotiateAuth())
 Options
 -------
 
-  - `username`: Username.  
+  - `username`: Username.
     Default: None
 
-  - `password`: Password.  
+  - `password`: Password.
     Default: None
 
-  - `domain`: NT Domain name.  
-    Default: '.' for local account.
+  - `domain`: NT Domain name.
+    Default: None
 
-  - `service`: Kerberos Service type for remote Service Principal
-    Name.  
+  - `service`: Kerberos Service type for remote Service Principal.
+    Name.
     Default: 'HTTP'
 
-  - `host`: Host name for Service Principal Name.  
+  - `host`: Host name for Service Principal Name.
     Default: Extracted from request URI
 
   - `delegate`: Indicates that the user's credentials are to be delegated to the server.

--- a/requests_negotiate_sspi/requests_negotiate_sspi.py
+++ b/requests_negotiate_sspi/requests_negotiate_sspi.py
@@ -33,7 +33,6 @@ class HttpNegotiateAuth(AuthBase):
             username: Username.
             password: Password.
             domain: NT Domain name.
-                Default: '.' for local account.
             service: Kerberos Service type for remote Service Principal Name.
                 Default: 'HTTP'
             host: Host name for Service Principal Name.
@@ -45,9 +44,6 @@ class HttpNegotiateAuth(AuthBase):
             This allows for single-sign-on to domain resources if the user is currently logged on
             with a domain account.
         """
-        if domain is None:
-            domain = '.'
-
         if username is not None and password is not None:
             self._auth_info = (username, domain, password)
 


### PR DESCRIPTION
Remove implication of a local domain (local SAM account) which forced you to *always* supply a domain although Kerberos can derive default one automatically.

This fixes #37