### PR TITLE
Fix to support urllib3 version 2+ and requests > 2.26.0

### DIFF
--- a/requests_negotiate_sspi/__init__.py
+++ b/requests_negotiate_sspi/__init__.py
@@ -4,29 +4,17 @@ __all__ = ['requests_negotiate_sspi']
 from .requests_negotiate_sspi import HttpNegotiateAuth  # noqa
 
 # Monkeypatch urllib3 to expose the peer certificate
-HTTPResponse = requests.packages.urllib3.response.HTTPResponse
-orig_HTTPResponse__init__ = HTTPResponse.__init__
-
 HTTPAdapter = requests.adapters.HTTPAdapter
 orig_HTTPAdapter_build_response = HTTPAdapter.build_response
-
-
-def new_HTTPResponse__init__(self, *args, **kwargs):
-    orig_HTTPResponse__init__(self, *args, **kwargs)
-    try:
-        self.peercert = self._connection.sock.getpeercert(binary_form=True)
-    except AttributeError:
-        self.peercert = None
 
 
 def new_HTTPAdapter_build_response(self, request, resp):
     response = orig_HTTPAdapter_build_response(self, request, resp)
     try:
-        response.peercert = resp.peercert
+        response.peercert = resp.connection.sock.getpeercert(binary_form=True)
     except AttributeError:
         response.peercert = None
     return response
 
 
-HTTPResponse.__init__ = new_HTTPResponse__init__
 HTTPAdapter.build_response = new_HTTPAdapter_build_response

--- a/requests_negotiate_sspi/__init__.py
+++ b/requests_negotiate_sspi/__init__.py
@@ -11,7 +11,7 @@ orig_HTTPAdapter_build_response = HTTPAdapter.build_response
 def new_HTTPAdapter_build_response(self, request, resp):
     response = orig_HTTPAdapter_build_response(self, request, resp)
     try:
-        response.peercert = resp.connection.sock.getpeercert(binary_form=True)
+        response.peercert = resp._connection.sock.getpeercert(binary_form=True)
     except AttributeError:
         response.peercert = None
     return response


### PR DESCRIPTION
Simplify monkeypatch and enable support for `urllib3 >= 2.0.0` and `requests > 2.26.0`.

Current code doesn't work for `urllib3 >= 2.0.0` because `self._connection is None` in `HTTPResonse.__init__` . 

Tested in python3.12 with `requests==2.26.0` with `urllib3==1.26.20` and also `requests==2.32.4` with `urllib3==2.5.0`.

Tested in python3.10 with `requests==2.19.0` with `urllib3=1.23`

Tested with `requests==2.0.0`,  `requests==2.11.0` , and  `requests==2.12.0` in python 3.10 but had to fixup move of classes from `collections` to `collections.abc` (requests library didn't officially support 3.10 until version 2.27.0).


This is related to #25 but reduces the monkey patching to `requests`, removing the monkey patching of `urllib3` . Does not completely remove the need monkey patch but also retains existing interface so existing code doesn't need to change.